### PR TITLE
Feat/hpa

### DIFF
--- a/k8s/base/deployment.yml
+++ b/k8s/base/deployment.yml
@@ -48,8 +48,8 @@ spec:
               memory: '128Mi'
               cpu: '100m'
             limits:
-              memory: '256Mi'
-              cpu: '250m'
+              memory: '512Mi'
+              cpu: '500m'
           ports:
             - containerPort: 3000
           livenessProbe:

--- a/k8s/base/hpa.yml
+++ b/k8s/base/hpa.yml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: chat-hpa
+spec:
+  maxReplicas: 15 # define max replica count
+  minReplicas: 3  # define min replica count
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: chat
+  targetCPUUtilizationPercentage: 50 # target CPU utilization

--- a/k8s/base/kustomization.yml
+++ b/k8s/base/kustomization.yml
@@ -1,4 +1,5 @@
 resources:
   - deployment.yml
+  - hpa.yml
   - ingress.yml
   - service.yml


### PR DESCRIPTION
- adds basic horizontal pod autoscaler

In the future we'll probably want to shift to using a vertical pod autoscaler (VPA) and a HPA based on some external metric like http requests or keda with an event stream. As of now HPA is based on CPU metric.