### PR TITLE
refactor/limit_chat_api_call

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -104,7 +104,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
   ) => {
     const chatBody: ChatBody = {
       model: updatedConversation.model,
-      messages: updatedConversation.messages.slice(-3),
+      messages: updatedConversation.messages.slice(-6),
       key: apiKey,
       prompt: updatedConversation.prompt,
       temperature: updatedConversation.temperature,

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -99,12 +99,15 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
     return updatedConversation
   }
 
+  //added to prevent chat token limit being hit too early. Will still happen with large messages though
+  let limitedConversationMessages = updateConversation.messages.slice(-3);
+
   const makeRequest = async (
       plugin: Plugin | null, updatedConversation: Conversation
   ) => {
     const chatBody: ChatBody = {
       model: updatedConversation.model,
-      messages: updatedConversation.messages,
+      messages: limitedConversationMessages,
       key: apiKey,
       prompt: updatedConversation.prompt,
       temperature: updatedConversation.temperature,

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -99,15 +99,12 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
     return updatedConversation
   }
 
-  //added to prevent chat token limit being hit too early. Will still happen with large messages though
-  let limitedConversationMessages = updateConversation.messages.slice(-3);
-
   const makeRequest = async (
       plugin: Plugin | null, updatedConversation: Conversation
   ) => {
     const chatBody: ChatBody = {
       model: updatedConversation.model,
-      messages: limitedConversationMessages,
+      messages: updatedConversation.messages.slice(-3),
       key: apiKey,
       prompt: updatedConversation.prompt,
       temperature: updatedConversation.temperature,


### PR DESCRIPTION
- adds a message limit of 3 to the chat api call and prevents the token limit from eventually running out. Will still happen if large messages are created though. 


untested right now