### PR TITLE
Add file upload authorization check

### DIFF
--- a/components/Chat/ChatInput/ChatInputFile.tsx
+++ b/components/Chat/ChatInput/ChatInputFile.tsx
@@ -1,6 +1,7 @@
 import FileIcon from "@/components/Icons/file";
 import React, {ChangeEvent, Dispatch, MutableRefObject, SetStateAction, useRef} from "react";
 import {ChatInputSubmitTypes, FileMessageContent, ImageMessageContent} from "@/types/chat";
+import {userAuthorizedForFileUploads} from "@/utils/app/userAuth";
 
 interface ChatInputFileProps {
     onFileUpload: (
@@ -19,6 +20,9 @@ interface ChatInputFileProps {
 
 const ChatInputFile = ({onFileUpload, setSubmitType, setFilePreviews, setFileFieldValue, setImageFieldValue}: ChatInputFileProps) => {
     const fileInputRef: MutableRefObject<any> = useRef(null)
+    if (!userAuthorizedForFileUploads())
+        return null;
+
     return <>
         <input
             type="file"

--- a/components/Chat/ChatInput/ChatInputFile.tsx
+++ b/components/Chat/ChatInput/ChatInputFile.tsx
@@ -1,7 +1,8 @@
 import FileIcon from "@/components/Icons/file";
-import React, {ChangeEvent, Dispatch, MutableRefObject, SetStateAction, useRef} from "react";
+import React, {ChangeEvent, Dispatch, MutableRefObject, SetStateAction, useContext, useRef} from "react";
 import {ChatInputSubmitTypes, FileMessageContent, ImageMessageContent} from "@/types/chat";
 import {userAuthorizedForFileUploads} from "@/utils/app/userAuth";
+import HomeContext from "@/pages/api/home/home.context";
 
 interface ChatInputFileProps {
     onFileUpload: (
@@ -20,7 +21,14 @@ interface ChatInputFileProps {
 
 const ChatInputFile = ({onFileUpload, setSubmitType, setFilePreviews, setFileFieldValue, setImageFieldValue}: ChatInputFileProps) => {
     const fileInputRef: MutableRefObject<any> = useRef(null)
-    if (!userAuthorizedForFileUploads())
+
+    const {
+        state: {
+            user,
+        },
+        dispatch: homeDispatch,
+    } = useContext(HomeContext);
+    if (!userAuthorizedForFileUploads(user))
         return null;
 
     return <>

--- a/components/Chat/ChatInput/ChatInputImage.tsx
+++ b/components/Chat/ChatInput/ChatInputImage.tsx
@@ -1,8 +1,9 @@
 import ImageIcon from "@/components/Icons/image";
-import React, {Dispatch, MutableRefObject, SetStateAction, useRef} from "react";
+import React, {Dispatch, MutableRefObject, SetStateAction, useContext, useRef} from "react";
 import {ChatInputSubmitTypes, ImageMessageContent, TextMessageContent} from "@/types/chat";
 import toast from 'react-hot-toast';
 import {userAuthorizedForFileUploads} from "@/utils/app/userAuth";
+import HomeContext from "@/pages/api/home/home.context";
 
 const onImageUpload = (
     event: React.ChangeEvent<any>,
@@ -85,7 +86,14 @@ const ChatInputImage = (
     }: ChatInputImageProps
 ) => {
     const imageInputRef: MutableRefObject<any> = useRef(null);
-    if (!userAuthorizedForFileUploads())
+
+    const {
+        state: {
+            user,
+        },
+        dispatch: homeDispatch,
+    } = useContext(HomeContext);
+    if (!userAuthorizedForFileUploads(user))
         return null;
 
     return <>

--- a/components/Chat/ChatInput/ChatInputImage.tsx
+++ b/components/Chat/ChatInput/ChatInputImage.tsx
@@ -2,6 +2,7 @@ import ImageIcon from "@/components/Icons/image";
 import React, {Dispatch, MutableRefObject, SetStateAction, useRef} from "react";
 import {ChatInputSubmitTypes, ImageMessageContent, TextMessageContent} from "@/types/chat";
 import toast from 'react-hot-toast';
+import {userAuthorizedForFileUploads} from "@/utils/app/userAuth";
 
 const onImageUpload = (
     event: React.ChangeEvent<any>,
@@ -84,7 +85,8 @@ const ChatInputImage = (
     }: ChatInputImageProps
 ) => {
     const imageInputRef: MutableRefObject<any> = useRef(null);
-
+    if (!userAuthorizedForFileUploads())
+        return null;
 
     return <>
         <input

--- a/components/Chat/ChatInput/ChatInputImageCapture.tsx
+++ b/components/Chat/ChatInput/ChatInputImageCapture.tsx
@@ -1,12 +1,12 @@
 import React, {
-    Dispatch,
-    FC,
-    MouseEventHandler,
-    MutableRefObject,
-    SetStateAction,
-    useEffect,
-    useRef,
-    useState
+  Dispatch,
+  FC,
+  MouseEventHandler,
+  MutableRefObject,
+  SetStateAction, useContext,
+  useEffect,
+  useRef,
+  useState
 } from "react";
 import {IconCamera, IconX} from "@tabler/icons-react";
 import { ChatInputSubmitTypes, ImageMessageContent } from "@/types/chat";
@@ -16,6 +16,7 @@ import {CameraModal} from "@/components/Chat/ChatInput/CameraModal";
 import {onImageUpload} from "@/components/Chat/ChatInputEventHandlers/image-upload";
 import {isMobile} from "@/utils/app/env";
 import {userAuthorizedForFileUploads} from "@/utils/app/userAuth";
+import HomeContext from "@/pages/api/home/home.context";
 
 
 
@@ -94,7 +95,14 @@ const ChatInputImageCapture: FC<ChatInputImageCaptureProps> = (
       openModal();
     }
   };
-  if (!userAuthorizedForFileUploads())
+
+  const {
+    state: {
+      user,
+    },
+    dispatch: homeDispatch,
+  } = useContext(HomeContext);
+  if (!userAuthorizedForFileUploads(user))
     return null;
 
   return (

--- a/components/Chat/ChatInput/ChatInputImageCapture.tsx
+++ b/components/Chat/ChatInput/ChatInputImageCapture.tsx
@@ -15,6 +15,7 @@ import {useTranslation} from "next-i18next";
 import {CameraModal} from "@/components/Chat/ChatInput/CameraModal";
 import {onImageUpload} from "@/components/Chat/ChatInputEventHandlers/image-upload";
 import {isMobile} from "@/utils/app/env";
+import {userAuthorizedForFileUploads} from "@/utils/app/userAuth";
 
 
 
@@ -93,7 +94,8 @@ const ChatInputImageCapture: FC<ChatInputImageCaptureProps> = (
       openModal();
     }
   };
-
+  if (!userAuthorizedForFileUploads())
+    return null;
 
   return (
         <>

--- a/utils/app/userAuth.ts
+++ b/utils/app/userAuth.ts
@@ -1,0 +1,4 @@
+
+export const userAuthorizedForFileUploads = (): boolean => {
+  return true;
+}

--- a/utils/app/userAuth.ts
+++ b/utils/app/userAuth.ts
@@ -1,4 +1,7 @@
+const isUSBased = (email: string): boolean => {
+  return email?.toLowerCase().indexOf('newyork') >= 0;
+}
 
-export const userAuthorizedForFileUploads = (): boolean => {
-  return true;
+export const userAuthorizedForFileUploads = (user: {mail: string}): boolean => {
+  return isUSBased(user?.mail ?? '');
 }

--- a/utils/app/userAuth.ts
+++ b/utils/app/userAuth.ts
@@ -1,7 +1,9 @@
+import {Session} from "next-auth";
+
 const isUSBased = (email: string): boolean => {
   return email?.toLowerCase().indexOf('newyork') >= 0;
 }
 
-export const userAuthorizedForFileUploads = (user: {mail: string}): boolean => {
+export const userAuthorizedForFileUploads = (user: Session["user"] | undefined): boolean => {
   return isUSBased(user?.mail ?? '');
 }


### PR DESCRIPTION
This commit adds a new authorization check for file uploads in chat input components. It introduces a utility function to arbitrarily determine if a user is authorized for file uploads, and conditionally renders file-related input elements based on this authorization.

This is prep work for disabling this feature for any file processing logic that needs to be handled differently.