### PR TITLE
fix/logging_for_fileupload

### DIFF
--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -271,9 +271,16 @@ export default class ChatService {
           content: `Is the following query related to humanitarian issues, global health crises, or the work of organizations like MSF? Query: "${query}"`,
         },
       ],
+      no_log: true,
+    } as OpenAI.Chat.Completions.ChatCompletionCreateParams & {
+      no_log: boolean;
     });
 
-    const answer = response.choices[0]?.message?.content?.toLowerCase().trim();
+    const typedAnswer = response as OpenAI.Chat.Completions.ChatCompletion;
+
+    const answer = typedAnswer.choices[0]?.message?.content
+      ?.toLowerCase()
+      .trim();
     console.log('relevant: ', answer);
     return answer === 'yes';
   }

--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -183,6 +183,7 @@ export default class ChatService {
           prompt,
           token,
           modelId,
+          user,
         }); //""; // await parseAndQueryFileLangchainOpenAI(file, prompt);
 
         console.log('File summarized successfully.');

--- a/utils/app/documentSummary.ts
+++ b/utils/app/documentSummary.ts
@@ -50,9 +50,9 @@ async function summarizeChunk(
     max_tokens: 1000,
     stream: false,
     user: JSON.stringify(user),
-    langchain: true,
+    no_log: true,
   } as OpenAI.Chat.Completions.ChatCompletionCreateParams & {
-    langchain: boolean;
+    no_log: boolean;
   });
 
   const typedChunkSummary =

--- a/utils/app/documentSummary.ts
+++ b/utils/app/documentSummary.ts
@@ -1,4 +1,5 @@
 import { JWT } from 'next-auth';
+import { Session } from 'next-auth';
 
 import {
   APIM_CHAT_ENDPONT,
@@ -21,6 +22,7 @@ interface parseAndQueryFilterOpenAIArguments {
   token: JWT;
   modelId: string;
   maxLength?: number;
+  user: Session['user'];
 }
 
 async function summarizeChunk(
@@ -28,6 +30,7 @@ async function summarizeChunk(
   modelId: string,
   prompt: string,
   chunk: string,
+  user: Session['user'],
 ): Promise<string> {
   const summaryPrompt: string = `Summarize the following text with relevance to the prompt, but keep enough details to maintain the tone, character, and content of the original. If nothing is relevant, then return an empty string:\n\n\`\`\`prompt\n${prompt}\`\`\`\n\n\`\`\`text\n${chunk}\n\`\`\``;
   const chunkSummary = await azureOpenai.chat.completions.create({
@@ -42,7 +45,7 @@ async function summarizeChunk(
         role: 'user',
         content: summaryPrompt,
       },
-    ] as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+    ],
     temperature: 0.1,
     max_tokens: 1000,
     stream: false,
@@ -64,6 +67,7 @@ export async function parseAndQueryFileOpenAI({
   token,
   modelId,
   maxLength = 6000,
+  user,
 }: parseAndQueryFilterOpenAIArguments): Promise<ReadableStream<any>> {
   const fileContent = await loadDocument(file);
   let chunks: string[] = splitIntoChunks(fileContent);
@@ -87,10 +91,12 @@ export async function parseAndQueryFileOpenAI({
 
   while (chunks.length > 0) {
     const chunkPromises = chunks.map((chunk) =>
-      summarizeChunk(azureOpenai, modelId, prompt, chunk).catch((error) => {
-        console.error(error);
-        return null;
-      }),
+      summarizeChunk(azureOpenai, modelId, prompt, chunk, user).catch(
+        (error) => {
+          console.error(error);
+          return null;
+        },
+      ),
     );
 
     const summaries = await Promise.all(chunkPromises);
@@ -122,13 +128,17 @@ export async function parseAndQueryFileOpenAI({
         role: 'user',
         content: finalPrompt,
       },
-    ] as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+    ],
     temperature: 0.1,
     max_tokens: null,
     stream: true,
+    user: JSON.stringify(user),
+    file_upload: true,
+  } as OpenAI.Chat.Completions.ChatCompletionCreateParams & {
+    file_upload: boolean;
   });
 
-  const stream: ReadableStream<any> = OpenAIStream(response);
+  const stream: ReadableStream<any> = OpenAIStream(response as any);
   return stream;
 }
 


### PR DESCRIPTION
- adds a "no_log" property to file chunking and relevancy checks AI requests. This is so we only track actual user requests in the dashboard views.
- right now apim parses these body properties, removes them, and then sends the correct request to openai. Realistically these should probably be header properties instead of in the body or how we handle logging should change entirely. Just getting this fix in for now so we can fix production logging and then work on a better setup. Knowing we made need to present this data soon. 