### PR TITLE
Ensure the features dropdown menu is responsive

### DIFF
--- a/components/Chat/ChatInput/ChatDropdownWeb.tsx
+++ b/components/Chat/ChatInput/ChatDropdownWeb.tsx
@@ -105,6 +105,26 @@ const Dropdown: React.FC<DropdownProps> = ({
     }
   };
 
+    {/* Logic to handle clicks outside the Dropdown Menu */}
+    useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+          setIsOpen(false);
+        }
+      };
+  
+      if (isOpen) {
+        document.addEventListener('mousedown', handleClickOutside);
+      } else {
+        document.removeEventListener('mousedown', handleClickOutside);
+      }
+       
+      {/* Cleanup on component unmount or when `isOpen` changes */}
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, [isOpen]);  
+
   useEffect(() => {
     if (isOpen) {
       dropdownRef.current?.focus();


### PR DESCRIPTION
Changes introduced in this PR can be observed in the following screen recordings: 

The features dropdown menu that appears as a result of clicking the icon near the search input bar would not close when a user clicked outside of its bounds:

https://github.com/user-attachments/assets/2e6dc71c-bca3-4770-b9ae-03af26c39d9c

With the combined effects of useEffect & the mouse down event listener the menu is now responsive & closes when a user clicks outside of its bounds: 

https://github.com/user-attachments/assets/74714ff5-3d71-431a-bebd-537e1a66134f


Hopefully the attached videos are viewable to all reviewers. 