### PR TITLE
removed 4.5-preview and added legacy api check

### DIFF
--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -29,7 +29,7 @@ import {
   Message,
   TextMessageContent,
 } from '@/types/chat';
-import { OpenAIModelID, OpenAIVisionModelID } from '@/types/openai';
+import { OpenAIModelID, OpenAIVisionModelID, OpenAIModels } from '@/types/openai';
 
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 
@@ -483,6 +483,14 @@ export default class ChatService {
     );
 
     let modelToUse = model.id;
+    
+    // Check if the model is legacy and migrate to gpt-4o
+    const modelConfig = Object.values(OpenAIModels).find(m => m.id === model.id);
+    if (modelConfig?.isLegacy) {
+      console.log(`Migrating legacy model ${model.id} to ${OpenAIModelID.GPT_4o}`);
+      modelToUse = OpenAIModelID.GPT_4o;
+    }
+    
     if (isValidModel && needsToHandleImages && !isImageModel) {
       modelToUse = 'gpt-4o';
     } else if (modelToUse == null || !isValidModel) {

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -73,11 +73,11 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   },
   [OpenAIModelID.GPT_45]: {
     id: OpenAIModelID.GPT_45,
-    name: 'gpt-4.5',
+    name: 'gpt-4.5-preview',
     maxLength: 80000,
     tokenLimit: 8000,
     modelType: 'foundational',
-    isLegacy: false,
+    isLegacy: true,
   },
   [OpenAIModelID.GPT_o1]: {
     id: OpenAIModelID.GPT_o1,


### PR DESCRIPTION
- Original hotfix had a transition from 4.5-preview to 4.5 but I misunderstood in Azure AI Foundry that 4.5 is gone all together now. I couldn't really fully test in dev since dev never had access to 4.5 but confirmed when it made it to beta. 

- this removes 4.5 and adds a legacy fallback in the api handler.