### PR TITLE
Bug/prompt fixing

### DIFF
--- a/__tests__/dom/components/Chat/ChatInput/ChatInputSelection.test.tsx
+++ b/__tests__/dom/components/Chat/ChatInput/ChatInputSelection.test.tsx
@@ -1,0 +1,447 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import userEvent from '@testing-library/user-event';
+
+import { ChatInput } from '@/components/Chat/ChatInput';
+import { CommandDefinition, CommandType } from '@/services/commandParser';
+import { Prompt } from '@/types/prompt';
+import { Message } from '@/types/chat';
+import { Plugin } from '@/types/plugin';
+import HomeContext from '@/pages/api/home/home.context';
+
+// Mock dependencies
+vi.mock('@tabler/icons-react', () => ({
+  IconArrowDown: () => <div data-testid="icon-arrow-down" />,
+  IconRepeat: () => <div data-testid="icon-repeat" />,
+  IconCommand: () => <div data-testid="icon-command" />,
+  IconRobot: () => <div data-testid="icon-robot" />,
+  IconSettings: () => <div data-testid="icon-settings" />,
+  IconHelp: () => <div data-testid="icon-help" />,
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ 
+    t: (key: string, params?: any) => {
+      if (params) {
+        return `${key} ${JSON.stringify(params)}`;
+      }
+      return key;
+    }
+  }),
+}));
+
+// Mock command parser
+vi.mock('@/services/localizedCommandParser', () => ({
+  LocalizedCommandParser: {
+    getInstance: () => ({
+      parseLocalizedInput: vi.fn(),
+      getLocalizedCommandSuggestions: vi.fn(() => []),
+      parseInput: vi.fn(),
+      executeCommand: vi.fn(() => ({ success: true })),
+    }),
+  },
+}));
+
+// Mock components
+vi.mock('@/components/Chat/ChatInput/ChatFileUploadPreviews', () => ({
+  default: () => <div data-testid="file-upload-previews" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputAgentToggle', () => ({
+  ChatInputAgentToggle: () => <div data-testid="agent-toggle" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputFile', () => ({
+  default: () => <div data-testid="input-file" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputImage', () => ({
+  default: () => <div data-testid="input-image" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputImageCapture', () => ({
+  default: () => <div data-testid="input-image-capture" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputSubmitButton', () => ({
+  default: () => <div data-testid="submit-button" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputTranscribe', () => ({
+  default: () => <div data-testid="input-transcribe" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputTranslate', () => ({
+  default: () => <div data-testid="input-translate" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/ChatInputVoiceCapture', () => ({
+  default: () => <div data-testid="voice-capture" />,
+}));
+
+vi.mock('@/components/Chat/ChatInput/Dropdown', () => ({
+  default: () => <div data-testid="chat-dropdown" />,
+}));
+
+vi.mock('@/components/Chat/ModelList', () => ({
+  ModelList: () => <div data-testid="model-list" />,
+}));
+
+vi.mock('@/components/Chat/PromptList', () => ({
+  PromptList: ({ prompts, onSelect, activePromptIndex }: any) => (
+    <div data-testid="prompt-list">
+      {prompts.map((prompt: any, index: number) => (
+        <div 
+          key={prompt.id} 
+          data-testid={`prompt-${index}`}
+          onClick={() => onSelect(index)}
+          className={index === activePromptIndex ? 'active' : ''}
+        >
+          {prompt.name}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/Chat/VariableModal', () => ({
+  VariableModal: ({ prompt, variables, onSubmit, onClose }: any) => (
+    <div data-testid="variable-modal">
+      <h2>{prompt?.name}</h2>
+      <p>{prompt?.description}</p>
+      {variables.map((v: string, i: number) => (
+        <div key={i}>
+          <label>{v}</label>
+          <input 
+            data-testid={`variable-${v}`}
+            placeholder={`Enter a value for ${v}...`}
+          />
+        </div>
+      ))}
+      <button onClick={() => {
+        const values = variables.map((v: string, i: number) => 
+          i === 0 ? 'John' : '30'
+        );
+        onSubmit(values);
+      }}>Submit</button>
+    </div>
+  ),
+}));
+
+// Mock utils
+vi.mock('@/utils/app/modelUsage', () => ({
+  incrementModelUsage: vi.fn(),
+  getModelUsageCount: vi.fn(() => 0),
+}));
+
+vi.mock('@/utils/app/promptUsage', () => ({
+  incrementPromptUsage: vi.fn(),
+  getPromptUsageCount: vi.fn(() => 0),
+}));
+
+describe('ChatInput Selection Logic', () => {
+  const mockOnSend = vi.fn();
+  const mockOnRegenerate = vi.fn();
+  const mockOnScrollDownClick = vi.fn();
+  const mockSetFilePreviews = vi.fn();
+  const stopConversationRef = { current: false };
+  const textareaRef = { current: null as HTMLTextAreaElement | null };
+
+  const mockPrompts: Prompt[] = [
+    {
+      id: 'prompt1',
+      name: 'Simple Prompt',
+      description: 'A simple prompt without variables',
+      content: 'This is a simple prompt',
+      model: { id: 'gpt-4', name: 'GPT-4' } as any,
+      folderId: null,
+    },
+    {
+      id: 'prompt2',
+      name: 'Variable Prompt',
+      description: 'A prompt with variables',
+      content: 'Hello {{name}}, your age is {{age}}',
+      model: { id: 'gpt-4', name: 'GPT-4' } as any,
+      folderId: null,
+    },
+  ];
+
+  const mockCommands: CommandDefinition[] = [
+    {
+      command: 'search',
+      type: CommandType.AGENT,
+      description: 'Search the web',
+      usage: '/search <query>',
+      examples: ['/search weather'],
+      execute: vi.fn(),
+    },
+    {
+      command: 'code',
+      type: CommandType.AGENT,
+      description: 'Code interpreter',
+      usage: '/code <request>',
+      examples: ['/code calculate'],
+      execute: vi.fn(),
+    },
+  ];
+
+  const mockHomeContextValue = {
+    state: {
+      selectedConversation: {
+        id: 'conv1',
+        name: 'Test Conversation',
+        messages: [],
+        model: { id: 'gpt-4', name: 'GPT-4' },
+        prompt: '',
+        temperature: 0.7,
+        folderId: null,
+      },
+      messageIsStreaming: false,
+      prompts: mockPrompts,
+    },
+    handleUpdateConversation: vi.fn(),
+    dispatch: vi.fn(),
+  };
+
+  const renderChatInput = (props = {}) => {
+    return render(
+      <HomeContext.Provider value={mockHomeContextValue}>
+        <ChatInput
+          onSend={mockOnSend}
+          onRegenerate={mockOnRegenerate}
+          onScrollDownClick={mockOnScrollDownClick}
+          stopConversationRef={stopConversationRef}
+          textareaRef={textareaRef}
+          showScrollDownButton={false}
+          filePreviews={[]}
+          setFilePreviews={mockSetFilePreviews}
+          {...props}
+        />
+      </HomeContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset refs
+    stopConversationRef.current = false;
+    textareaRef.current = document.createElement('textarea');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('Unified Selection Logic', () => {
+    it('handles prompt selection when "/" is typed', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox');
+      
+      // Type "/" to trigger prompt list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for prompt list to appear
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+      
+      // Check that prompts are shown
+      expect(screen.getByText('Simple Prompt')).toBeInTheDocument();
+      expect(screen.getByText('Variable Prompt')).toBeInTheDocument();
+    });
+
+    it('shows variable modal for prompts with variables', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox');
+      
+      // Type "/" to trigger prompt list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for prompt list
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+
+      // Click on the variable prompt (index 1)
+      const variablePrompt = screen.getByTestId('prompt-1');
+      await userEvent.click(variablePrompt);
+
+      // Check that modal appears with the prompt details
+      await waitFor(() => {
+        expect(screen.getByTestId('variable-modal')).toBeInTheDocument();
+      });
+      
+      expect(screen.getByText('Variable Prompt')).toBeInTheDocument();
+      expect(screen.getByText('A prompt with variables')).toBeInTheDocument();
+      // Variable inputs should be present
+      expect(screen.getByText('name')).toBeInTheDocument();
+      expect(screen.getByText('age')).toBeInTheDocument();
+    });
+
+    it('fills in prompt content without variables directly', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      
+      // Type "/" to trigger prompt list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for prompt list
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+
+      // Click on the simple prompt (index 0)
+      const simplePrompt = screen.getByTestId('prompt-0');
+      await userEvent.click(simplePrompt);
+
+      // Check that the textarea value is updated
+      await waitFor(() => {
+        expect(textarea.value).toBe('This is a simple prompt');
+      });
+    });
+  });
+
+  describe('Index Calculation with Commands and Prompts', () => {
+    it('correctly calculates indices when both commands and prompts are shown', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox');
+      
+      // Type "/" to trigger command/prompt list
+      await userEvent.type(textarea, '/');
+      
+      // Should show prompt list
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+      
+      // Verify prompts are shown
+      expect(screen.getByText('Simple Prompt')).toBeInTheDocument();
+      expect(screen.getByText('Variable Prompt')).toBeInTheDocument();
+    });
+  });
+
+  describe('Keyboard Navigation', () => {
+    it('navigates through combined list with arrow keys', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox');
+      
+      // Type "/" to trigger list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for list to appear
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+
+      // Navigate with arrow keys
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{ArrowDown}');
+      
+      // Press Enter to select
+      await userEvent.keyboard('{Enter}');
+      
+      // Verify selection was made (prompt list should close)
+      await waitFor(() => {
+        expect(screen.queryByTestId('prompt-list')).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes prompt list on Escape', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox');
+      
+      // Type "/" to trigger list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for list to appear
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+
+      // Press Escape
+      await userEvent.keyboard('{Escape}');
+      
+      // List should close
+      await waitFor(() => {
+        expect(screen.queryByTestId('prompt-list')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Variable Modal Interaction', () => {
+    it('submits variable values and updates textarea', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      
+      // Type "/" to trigger prompt list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for prompt list
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+
+      // Click on the variable prompt (index 1)
+      const variablePrompt = screen.getByTestId('prompt-1');
+      await userEvent.click(variablePrompt);
+
+      // Wait for modal
+      await waitFor(() => {
+        expect(screen.getByTestId('variable-modal')).toBeInTheDocument();
+      });
+
+      // Submit the modal (our mock automatically fills John and 30)
+      const submitButton = screen.getByText('Submit');
+      await userEvent.click(submitButton);
+
+      // Check that the textarea is updated with substituted values
+      await waitFor(() => {
+        expect(textarea.value).toBe('Hello John, your age is 30');
+      });
+    });
+
+    it('closes modal on outside click', async () => {
+      renderChatInput();
+      
+      const textarea = screen.getByRole('textbox');
+      
+      // Type "/" to trigger prompt list
+      await userEvent.type(textarea, '/');
+      
+      // Wait for prompt list
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-list')).toBeInTheDocument();
+      });
+      
+      // Click on the variable prompt (index 1)
+      const variablePrompt = screen.getByTestId('prompt-1');
+      await userEvent.click(variablePrompt);
+
+      // Wait for modal
+      await waitFor(() => {
+        expect(screen.getByTestId('variable-modal')).toBeInTheDocument();
+      });
+
+      // Since we can't easily simulate outside click with our mock,
+      // let's just verify the modal is showing
+      expect(screen.getByText('Variable Prompt')).toBeInTheDocument();
+      expect(screen.getByText('name')).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/dom/components/Chat/ChatInput/ChatInputSelection.test.tsx
+++ b/__tests__/dom/components/Chat/ChatInput/ChatInputSelection.test.tsx
@@ -39,6 +39,15 @@ vi.mock('next-i18next', () => ({
   }),
 }));
 
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    locale: 'en',
+    locales: ['en', 'fr'],
+    push: vi.fn(),
+    asPath: '/',
+  }),
+}));
+
 // Mock command parser
 vi.mock('@/services/localizedCommandParser', () => ({
   LocalizedCommandParser: {

--- a/__tests__/dom/components/Chat/PromptList.test.tsx
+++ b/__tests__/dom/components/Chat/PromptList.test.tsx
@@ -1,0 +1,332 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import userEvent from '@testing-library/user-event';
+
+import { PromptList } from '@/components/Chat/PromptList';
+import { CommandDefinition, CommandType } from '@/services/commandParser';
+import { Prompt } from '@/types/prompt';
+
+// Mock icons
+vi.mock('@tabler/icons-react', () => ({
+  IconCommand: (props: any) => <svg data-testid="icon-command" {...props} />,
+  IconRobot: (props: any) => <svg data-testid="icon-robot" {...props} />,
+  IconSettings: (props: any) => <svg data-testid="icon-settings" {...props} />,
+  IconHelp: (props: any) => <svg data-testid="icon-help" {...props} />,
+}));
+
+// Mock next-i18next
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('PromptList Component', () => {
+  const mockOnSelect = vi.fn();
+  const mockOnMouseOver = vi.fn();
+  const mockOnImmediateCommandExecution = vi.fn();
+  const mockPromptListRef = { current: null };
+
+  const mockPrompts: Prompt[] = [
+    {
+      id: '1',
+      name: 'Test Prompt 1',
+      description: 'Description 1',
+      content: 'Content 1',
+      model: { id: 'model1', name: 'Model 1' } as any,
+      folderId: null,
+    },
+    {
+      id: '2',
+      name: 'Test Prompt 2',
+      description: 'Description 2',
+      content: 'Content with {{variable}}',
+      model: { id: 'model2', name: 'Model 2' } as any,
+      folderId: null,
+    },
+  ];
+
+  const mockCommands: CommandDefinition[] = [
+    {
+      command: 'search',
+      type: CommandType.AGENT,
+      description: 'Search the web',
+      usage: '/search <query>',
+      examples: ['/search weather today'],
+      execute: vi.fn(),
+    },
+    {
+      command: 'settings',
+      type: CommandType.SETTINGS,
+      description: 'Open settings',
+      usage: '/settings',
+      examples: ['/settings'],
+      execute: vi.fn(),
+    },
+    {
+      command: 'help',
+      type: CommandType.UTILITY,
+      description: 'Show help',
+      usage: '/help',
+      examples: ['/help'],
+      execute: vi.fn(),
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('Rendering', () => {
+    it('renders only prompts when showCommands is false', () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={false}
+        />
+      );
+
+      expect(screen.getByText('Test Prompt 1')).toBeInTheDocument();
+      expect(screen.getByText('Test Prompt 2')).toBeInTheDocument();
+      expect(screen.queryByText('/search')).not.toBeInTheDocument();
+    });
+
+    it('renders both commands and prompts when showCommands is true', () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      // Commands should be rendered
+      expect(screen.getByText('/search')).toBeInTheDocument();
+      expect(screen.getByText('/settings')).toBeInTheDocument();
+      expect(screen.getByText('/help')).toBeInTheDocument();
+
+      // Prompts should also be rendered
+      expect(screen.getByText('Test Prompt 1')).toBeInTheDocument();
+      expect(screen.getByText('Test Prompt 2')).toBeInTheDocument();
+    });
+
+    it('shows active item with correct styling', () => {
+      const { rerender } = render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      // First command should be active
+      const firstCommand = screen.getByText('/search').closest('li');
+      expect(firstCommand).toHaveClass('bg-gray-200');
+
+      // Change active index to a prompt (index 3 = first prompt when 3 commands shown)
+      rerender(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={3}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      const firstPrompt = screen.getByText('Test Prompt 1').closest('li');
+      expect(firstPrompt).toHaveClass('bg-gray-200');
+    });
+  });
+
+  describe('Click Handling', () => {
+    it('calls onSelect with correct index when clicking a command', async () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      const searchCommand = screen.getByText('/search').closest('li');
+      await userEvent.click(searchCommand!);
+
+      expect(mockOnSelect).toHaveBeenCalledWith(0);
+    });
+
+    it('calls onSelect with correct index when clicking a prompt after commands', async () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      const firstPrompt = screen.getByText('Test Prompt 1').closest('li');
+      await userEvent.click(firstPrompt!);
+
+      // Should be called with index 3 (after 3 commands)
+      expect(mockOnSelect).toHaveBeenCalledWith(3);
+    });
+
+    it('calls onSelect with correct index when clicking a prompt without commands', async () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={false}
+        />
+      );
+
+      const secondPrompt = screen.getByText('Test Prompt 2').closest('li');
+      await userEvent.click(secondPrompt!);
+
+      expect(mockOnSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('executes immediate commands directly', async () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+          onImmediateCommandExecution={mockOnImmediateCommandExecution}
+        />
+      );
+
+      const settingsCommand = screen.getByText('/settings').closest('li');
+      await userEvent.click(settingsCommand!);
+
+      // Settings is an immediate execution command
+      expect(mockOnImmediateCommandExecution).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'settings' })
+      );
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Mouse Hover', () => {
+    it('calls onMouseOver with correct index when hovering over command', async () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      const helpCommand = screen.getByText('/help').closest('li');
+      await userEvent.hover(helpCommand!);
+
+      expect(mockOnMouseOver).toHaveBeenCalledWith(2); // Third command, index 2
+    });
+
+    it('calls onMouseOver with correct index when hovering over prompt', async () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      const secondPrompt = screen.getByText('Test Prompt 2').closest('li');
+      await userEvent.hover(secondPrompt!);
+
+      expect(mockOnMouseOver).toHaveBeenCalledWith(4); // After 3 commands, second prompt
+    });
+  });
+
+  describe('Empty State', () => {
+    it('shows empty message when no commands or prompts', () => {
+      render(
+        <PromptList
+          prompts={[]}
+          commands={[]}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      expect(screen.getByText('No commands or prompts found')).toBeInTheDocument();
+    });
+  });
+
+  describe('Command Type Icons', () => {
+    it('shows correct icons for different command types', () => {
+      render(
+        <PromptList
+          prompts={mockPrompts}
+          commands={mockCommands}
+          activePromptIndex={0}
+          onSelect={mockOnSelect}
+          onMouseOver={mockOnMouseOver}
+          promptListRef={mockPromptListRef}
+          showCommands={true}
+        />
+      );
+
+      // Check that icons are rendered for commands
+      const robotIcons = screen.getAllByTestId('icon-robot');
+      const settingsIcons = screen.getAllByTestId('icon-settings');
+      const helpIcons = screen.getAllByTestId('icon-help');
+
+      expect(robotIcons.length).toBeGreaterThan(0); // Agent command
+      expect(settingsIcons.length).toBeGreaterThan(0); // Settings command
+      expect(helpIcons.length).toBeGreaterThan(0); // Utility command
+    });
+  });
+});

--- a/__tests__/dom/services/frontendChatServices.test.ts
+++ b/__tests__/dom/services/frontendChatServices.test.ts
@@ -1,0 +1,649 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { makeRequest } from '@/services/frontendChatServices';
+import { getEndpoint } from '@/utils/app/api';
+
+import { Conversation, Message } from '@/types/chat';
+import { OpenAIModel, OpenAIModelID } from '@/types/openai';
+import { Plugin, PluginID } from '@/types/plugin';
+
+// Mock the API module
+vi.mock('@/utils/app/api', () => ({
+  getEndpoint: vi.fn(() => 'api/v2/chat'),
+}));
+
+describe('frontendChatServices', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let mockSetRequestStatusMessage: ReturnType<typeof vi.fn>;
+  let mockSetProgress: ReturnType<typeof vi.fn>;
+
+  const createMockConversation = (messages: Message[]): Conversation => ({
+    id: 'test-conversation',
+    name: 'Test Conversation',
+    messages,
+    model: {
+      id: OpenAIModelID.GPT_4,
+      name: 'GPT-4',
+      maxLength: 8000,
+      tokenLimit: 8000,
+    } as OpenAIModel,
+    prompt: 'Test prompt',
+    temperature: 0.5,
+    folderId: null,
+    promptTemplate: null,
+  });
+
+  beforeEach(() => {
+    mockSetRequestStatusMessage = vi.fn();
+    mockSetProgress = vi.fn();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Multi-file upload processing', () => {
+    it('should correctly parse v2 API response structure for multiple files', async () => {
+      // Create a multi-file message
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Compare these two files' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file1.pdf',
+            originalFilename: 'document1.pdf'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file2.sql',
+            originalFilename: 'query.sql'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      // Mock v2 API responses for individual file summaries
+      const mockV2Response1 = {
+        success: true,
+        data: {
+          text: 'This is a summary of document1.pdf containing important information.',
+          agentType: undefined,
+          confidence: undefined,
+          sources: [],
+          processingTime: 1234,
+          usedFallback: false,
+        },
+        metadata: {
+          version: '2.0',
+          timestamp: new Date().toISOString(),
+          requestId: 'req_123',
+        },
+      };
+
+      const mockV2Response2 = {
+        success: true,
+        data: {
+          text: 'This is a summary of query.sql with database operations.',
+          agentType: undefined,
+          confidence: undefined,
+          sources: [],
+          processingTime: 1234,
+          usedFallback: false,
+        },
+        metadata: {
+          version: '2.0',
+          timestamp: new Date().toISOString(),
+          requestId: 'req_124',
+        },
+      };
+
+      // Mock final comparison response (streaming)
+      const mockStreamResponse = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"text": "Comparison result"}\n\n'));
+          controller.close();
+        },
+      });
+
+      // Set up fetch mock to return different responses
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First file summary request
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockV2Response1),
+            text: () => Promise.resolve(JSON.stringify(mockV2Response1)),
+          });
+        } else if (callCount === 2) {
+          // Second file summary request
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockV2Response2),
+            text: () => Promise.resolve(JSON.stringify(mockV2Response2)),
+          });
+        } else {
+          // Final comparison request (streaming)
+          return Promise.resolve({
+            ok: true,
+            body: mockStreamResponse,
+          });
+        }
+      });
+
+      const result = await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true, // stream
+        mockSetProgress,
+        undefined, // stopConversationRef
+        true, // forceStandardChat
+      );
+
+      // Verify that status messages were updated
+      expect(mockSetRequestStatusMessage).toHaveBeenCalledWith('Handling multi-file processing. Please wait...');
+      expect(mockSetRequestStatusMessage).toHaveBeenCalledWith('Processing document1.pdf...');
+      expect(mockSetRequestStatusMessage).toHaveBeenCalledWith('Processing query.sql...');
+      expect(mockSetRequestStatusMessage).toHaveBeenCalledWith('File processing complete! Handling user prompt...');
+
+      // Verify progress was updated
+      expect(mockSetProgress).toHaveBeenCalled();
+
+      // Verify the final request body includes the summaries
+      const finalRequestCall = mockFetch.mock.calls[2];
+      const finalRequestBody = JSON.parse(finalRequestCall[1].body);
+      const finalMessage = finalRequestBody.messages[finalRequestBody.messages.length - 1];
+      
+      // Check that the comparison prompt includes both summaries
+      expect(finalMessage.content[0].text).toContain('document1.pdf');
+      expect(finalMessage.content[0].text).toContain('This is a summary of document1.pdf containing important information.');
+      expect(finalMessage.content[0].text).toContain('query.sql');
+      expect(finalMessage.content[0].text).toContain('This is a summary of query.sql with database operations.');
+      expect(finalMessage.content[0].text).toContain('Compare these two files');
+
+      // Verify result
+      expect(result.hasComplexContent).toBe(true);
+      expect(result.response).toBeDefined();
+    });
+
+    it('should handle v1 API backward compatibility', async () => {
+      // Create a multi-file message
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Analyze this file' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/legacy.txt',
+            originalFilename: 'legacy.txt'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/old.csv',
+            originalFilename: 'old.csv'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      // Mock v1 API responses (direct text field)
+      const mockV1Response1 = {
+        text: 'Legacy format summary of legacy.txt file.',
+      };
+
+      const mockV1Response2 = {
+        text: 'Old format summary of old.csv data.',
+      };
+
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockV1Response1),
+          });
+        } else if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockV1Response2),
+          });
+        } else {
+          return Promise.resolve({
+            ok: true,
+            body: new ReadableStream(),
+          });
+        }
+      });
+
+      await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true,
+        mockSetProgress,
+        undefined,
+        true,
+      );
+
+      // Verify the final request includes v1 format summaries
+      const finalRequestCall = mockFetch.mock.calls[2];
+      const finalRequestBody = JSON.parse(finalRequestCall[1].body);
+      const finalMessage = finalRequestBody.messages[finalRequestBody.messages.length - 1];
+      
+      expect(finalMessage.content[0].text).toContain('Legacy format summary of legacy.txt file.');
+      expect(finalMessage.content[0].text).toContain('Old format summary of old.csv data.');
+    });
+
+    it('should handle mixed v1 and v2 API responses', async () => {
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Compare files' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/new.pdf',
+            originalFilename: 'new.pdf'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/old.txt',
+            originalFilename: 'old.txt'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      // v2 response for first file
+      const mockV2Response = {
+        success: true,
+        data: {
+          text: 'New v2 format summary',
+        },
+        metadata: {},
+      };
+
+      // v1 response for second file
+      const mockV1Response = {
+        text: 'Old v1 format summary',
+      };
+
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockV2Response),
+          });
+        } else if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockV1Response),
+          });
+        } else {
+          return Promise.resolve({
+            ok: true,
+            body: new ReadableStream(),
+          });
+        }
+      });
+
+      await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true,
+        mockSetProgress,
+      );
+
+      const finalRequestCall = mockFetch.mock.calls[2];
+      const finalRequestBody = JSON.parse(finalRequestCall[1].body);
+      const finalMessage = finalRequestBody.messages[finalRequestBody.messages.length - 1];
+      
+      // Both summaries should be included
+      expect(finalMessage.content[0].text).toContain('New v2 format summary');
+      expect(finalMessage.content[0].text).toContain('Old v1 format summary');
+    });
+
+    it('should handle empty or null summary responses gracefully', async () => {
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Analyze files' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/empty.pdf',
+            originalFilename: 'empty.pdf'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/null.txt',
+            originalFilename: 'null.txt'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      // Response with undefined text in v2 format
+      const mockEmptyV2Response = {
+        success: true,
+        data: {
+          // text is undefined
+        },
+        metadata: {},
+      };
+
+      // Response with null text in v1 format
+      const mockNullV1Response = {
+        text: null,
+      };
+
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockEmptyV2Response),
+          });
+        } else if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockNullV1Response),
+          });
+        } else {
+          return Promise.resolve({
+            ok: true,
+            body: new ReadableStream(),
+          });
+        }
+      });
+
+      await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true,
+        mockSetProgress,
+      );
+
+      const finalRequestCall = mockFetch.mock.calls[2];
+      const finalRequestBody = JSON.parse(finalRequestCall[1].body);
+      const finalMessage = finalRequestBody.messages[finalRequestBody.messages.length - 1];
+      
+      // Should have empty summaries but still include file names
+      expect(finalMessage.content[0].text).toContain('empty.pdf');
+      expect(finalMessage.content[0].text).toContain('null.txt');
+      // The summaries should be empty strings (between the filename and closing backticks)
+      expect(finalMessage.content[0].text).toMatch(/```empty\.pdf\n\n```/);
+      expect(finalMessage.content[0].text).toMatch(/```null\.txt\n\n```/);
+    });
+
+    it('should handle image files alongside regular files', async () => {
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Analyze these items' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/document.pdf',
+            originalFilename: 'document.pdf'
+          },
+          { 
+            type: 'image_url', 
+            image_url: { url: 'https://example.com/image.png' }
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      const mockFileResponse = {
+        success: true,
+        data: {
+          text: 'Document summary',
+        },
+      };
+
+      const mockImageResponse = {
+        success: true,
+        data: {
+          text: 'Image analysis result',
+        },
+      };
+
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockFileResponse),
+          });
+        } else if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockImageResponse),
+          });
+        } else {
+          return Promise.resolve({
+            ok: true,
+            body: new ReadableStream(),
+          });
+        }
+      });
+
+      await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true,
+        mockSetProgress,
+      );
+
+      // Verify processing messages for both file types
+      expect(mockSetRequestStatusMessage).toHaveBeenCalledWith('Processing document.pdf...');
+      expect(mockSetRequestStatusMessage).toHaveBeenCalledWith('Processing Image: image.png...');
+
+      const finalRequestCall = mockFetch.mock.calls[2];
+      const finalRequestBody = JSON.parse(finalRequestCall[1].body);
+      const finalMessage = finalRequestBody.messages[finalRequestBody.messages.length - 1];
+      
+      expect(finalMessage.content[0].text).toContain('document.pdf');
+      expect(finalMessage.content[0].text).toContain('Document summary');
+      expect(finalMessage.content[0].text).toContain('Image: image.png');
+      expect(finalMessage.content[0].text).toContain('Image analysis result');
+    });
+
+    it('should update progress correctly during multi-file processing', async () => {
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Process files' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file1.pdf',
+            originalFilename: 'file1.pdf'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file2.pdf',
+            originalFilename: 'file2.pdf'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file3.pdf',
+            originalFilename: 'file3.pdf'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: { text: 'Summary' } }),
+        body: new ReadableStream(),
+      });
+
+      await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true,
+        mockSetProgress,
+      );
+
+      // Progress should be called multiple times
+      // Initial: 0%
+      expect(mockSetProgress).toHaveBeenCalledWith(0);
+      // After first file: 25% (1/4 including final step)
+      expect(mockSetProgress).toHaveBeenCalledWith(25);
+      // After second file: 50% (2/4)
+      expect(mockSetProgress).toHaveBeenCalledWith(50);
+      // After third file: 75% (3/4)
+      expect(mockSetProgress).toHaveBeenCalledWith(75);
+      // Before final request: still 75%
+      expect(mockSetProgress).toHaveBeenCalledWith(75);
+      // Reset after completion
+      expect(mockSetProgress).toHaveBeenCalledWith(null);
+    });
+
+    it('should not treat single file with text as complex content', async () => {
+      const singleFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Analyze this file' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/single.pdf',
+            originalFilename: 'single.pdf'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([singleFileMessage]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: new ReadableStream(),
+      });
+
+      const result = await makeRequest(
+        null,
+        mockSetRequestStatusMessage,
+        conversation,
+        'test-api-key',
+        [],
+        'System prompt',
+        0.5,
+        true,
+        mockSetProgress,
+      );
+
+      // Should not be treated as complex content (only 2 content items: text + 1 file)
+      expect(result.hasComplexContent).toBe(false);
+      // Should not show multi-file processing message
+      expect(mockSetRequestStatusMessage).not.toHaveBeenCalledWith('Handling multi-file processing. Please wait...');
+      // Should make only one request (no intermediate summaries)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle API errors during file processing', async () => {
+      const multiFileMessage: Message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Compare files' },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file1.pdf',
+            originalFilename: 'file1.pdf'
+          },
+          { 
+            type: 'file_url', 
+            url: 'https://example.com/file2.pdf',
+            originalFilename: 'file2.pdf'
+          },
+        ],
+        messageType: 'text',
+      };
+
+      const conversation = createMockConversation([multiFileMessage]);
+
+      // First request succeeds
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ data: { text: 'Summary 1' } }),
+          });
+        } else {
+          // Second request fails
+          return Promise.resolve({
+            ok: false,
+            text: () => Promise.resolve('API Error'),
+          });
+        }
+      });
+
+      await expect(
+        makeRequest(
+          null,
+          mockSetRequestStatusMessage,
+          conversation,
+          'test-api-key',
+          [],
+          'System prompt',
+          0.5,
+          true,
+          mockSetProgress,
+        )
+      ).rejects.toThrow('Request failed with status');
+    });
+  });
+});

--- a/__tests__/node/utils/app/citation.test.ts
+++ b/__tests__/node/utils/app/citation.test.ts
@@ -1,0 +1,398 @@
+import { extractCitationsFromContent } from '@/utils/app/citation';
+import { Citation } from '@/types/rag';
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+describe('extractCitationsFromContent', () => {
+  // Mock console methods
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Marker format extraction', () => {
+    it('should extract citations with marker format', () => {
+      const content = `This is the main content about AI.
+
+---CITATIONS_DATA---
+{"citations": [{"id": "1", "title": "AI Research", "url": "https://example.com"}]}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('This is the main content about AI.');
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0]).toEqual({
+        id: '1',
+        title: 'AI Research',
+        url: 'https://example.com'
+      });
+      expect(result.extractionMethod).toBe('marker');
+    });
+
+    it('should handle invalid JSON with marker format', () => {
+      const content = `Main content here.
+
+---CITATIONS_DATA---
+{invalid json}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Main content here.');
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('marker');
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should handle empty citations array with marker', () => {
+      const content = `Some text content.
+
+---CITATIONS_DATA---
+{"citations": []}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Some text content.');
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('marker');
+    });
+  });
+
+  describe('Legacy JSON format extraction', () => {
+    it('should extract citations from legacy JSON format', () => {
+      const content = `This is the main content.
+{"citations": [{"id": "2", "title": "Research Paper", "url": "https://paper.com"}]}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('This is the main content.');
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0].id).toBe('2');
+      expect(result.extractionMethod).toBe('regex');
+    });
+
+    it('should handle multiple citations in legacy format', () => {
+      const content = `Main text here.
+{"citations": [
+  {"id": "1", "title": "First", "url": "https://first.com"},
+  {"id": "2", "title": "Second", "url": "https://second.com"}
+]}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Main text here.');
+      expect(result.citations).toHaveLength(2);
+      expect(result.extractionMethod).toBe('regex');
+    });
+  });
+
+  describe('Code block handling - Critical Tests', () => {
+    it('should NOT extract JavaScript function as citations', () => {
+      const jsCode = `Here's a JavaScript function:
+
+function getData() {
+  return {
+    name: "test",
+    value: 123
+  };
+}`;
+
+      const result = extractCitationsFromContent(jsCode);
+      
+      expect(result.text).toBe(jsCode); // Original content preserved
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should NOT extract arrow function as citations', () => {
+      const arrowFunction = `Here's an arrow function:
+
+const handler = (data) => {
+  console.log(data);
+  return { success: true };
+}`;
+
+      const result = extractCitationsFromContent(arrowFunction);
+      
+      expect(result.text).toBe(arrowFunction);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should NOT extract Java class as citations', () => {
+      const javaCode = `Here's a Java class:
+
+public class Example {
+  private String name;
+  public Example(String name) {
+    this.name = name;
+  }
+}`;
+
+      const result = extractCitationsFromContent(javaCode);
+      
+      expect(result.text).toBe(javaCode);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should NOT extract C++ code as citations', () => {
+      const cppCode = `Here's C++ code:
+
+class Vector {
+  private:
+    int x, y;
+  public:
+    Vector(int x, int y) : x(x), y(y) {}
+}`;
+
+      const result = extractCitationsFromContent(cppCode);
+      
+      expect(result.text).toBe(cppCode);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should NOT extract console.log statements as citations', () => {
+      const consoleCode = `Debug output:
+
+console.log({
+  debug: true,
+  data: [1, 2, 3]
+});`;
+
+      const result = extractCitationsFromContent(consoleCode);
+      
+      expect(result.text).toBe(consoleCode);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should NOT extract JSON-like code structures', () => {
+      const jsonLikeCode = `Configuration object:
+
+const config = {
+  api: "https://api.example.com",
+  timeout: 5000,
+  retries: 3
+}`;
+
+      const result = extractCitationsFromContent(jsonLikeCode);
+      
+      expect(result.text).toBe(jsonLikeCode);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should handle Rust code with curly braces', () => {
+      const rustCode = `Rust example:
+
+fn main() {
+  let data = vec![1, 2, 3];
+  println!("{:?}", data);
+}`;
+
+      const result = extractCitationsFromContent(rustCode);
+      
+      expect(result.text).toBe(rustCode);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should handle TypeScript interfaces', () => {
+      const tsCode = `TypeScript interface:
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}`;
+
+      const result = extractCitationsFromContent(tsCode);
+      
+      expect(result.text).toBe(tsCode);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+  });
+
+  describe('Error handling and malformed JSON', () => {
+    it('should handle malformed JSON in legacy format', () => {
+      const content = `Some content
+{"citations": [incomplete}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(content); // Original preserved
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should handle JSON without citations key', () => {
+      const content = `Some content
+{"data": [{"id": "1"}]}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(content);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should handle citations that is not an array', () => {
+      const content = `Some content
+{"citations": "not an array"}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(content);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+      // Note: console.warn won't be called because the regex won't match
+      // due to missing array brackets in the JSON
+    });
+
+    it('should handle very short JSON-like content', () => {
+      const content = `Text
+{"a": 1}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(content);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+  });
+
+  describe('Content preservation', () => {
+    it('should preserve whitespace when no citations found', () => {
+      const content = `  Content with    
+      multiple spaces  
+  and newlines  `;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(content);
+      expect(result.citations).toHaveLength(0);
+    });
+
+    it('should handle empty string', () => {
+      const result = extractCitationsFromContent('');
+      
+      expect(result.text).toBe('');
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+
+    it('should handle content with only whitespace', () => {
+      const result = extractCitationsFromContent('   \n\t  ');
+      
+      expect(result.text).toBe('   \n\t  ');
+      expect(result.citations).toHaveLength(0);
+    });
+
+    it('should prefer marker format over legacy when both present', () => {
+      const content = `Main content
+
+---CITATIONS_DATA---
+{"citations": [{"id": "marker", "title": "From Marker"}]}`;
+
+      // Add separate content that looks like it might have legacy format
+      const contentWithBoth = content + '\n{"citations": [{"id": "legacy", "title": "From Legacy"}]}';
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Main content');
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0].id).toBe('marker');
+      expect(result.extractionMethod).toBe('marker');
+    });
+  });
+
+  describe('Valid citation extraction edge cases', () => {
+    it('should extract citations with special characters', () => {
+      // Use JSON.stringify to properly escape the special characters
+      const citations = [{"id": "1", "title": "Test & \"Special\" <chars>", "url": "https://example.com"}];
+      const content = `Content here
+{"citations": ${JSON.stringify(citations)}}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Content here');
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0].title).toBe('Test & "Special" <chars>');
+    });
+
+    it('should handle citations with Unicode characters', () => {
+      const content = `Unicode test
+{"citations": [{"id": "1", "title": "研究論文 📚", "url": "https://example.com"}]}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Unicode test');
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0].title).toBe('研究論文 📚');
+    });
+
+    it('should handle very long citation JSON', () => {
+      const longCitations = Array.from({ length: 10 }, (_, i) => ({
+        id: `${i + 1}`,
+        title: `Citation ${i + 1}`,
+        url: `https://example.com/${i + 1}`
+      }));
+      
+      const content = `Content
+{"citations": ${JSON.stringify(longCitations)}}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe('Content');
+      expect(result.citations).toHaveLength(10);
+    });
+  });
+
+  describe('Mixed content scenarios', () => {
+    it('should handle content with code followed by valid citations', () => {
+      const content = `Here's some code:
+
+function test() {
+  return { data: true };
+}
+
+And here are the references:
+
+---CITATIONS_DATA---
+{"citations": [{"id": "1", "title": "Reference", "url": "https://ref.com"}]}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(`Here's some code:
+
+function test() {
+  return { data: true };
+}
+
+And here are the references:`);
+      expect(result.citations).toHaveLength(1);
+      expect(result.extractionMethod).toBe('marker');
+    });
+
+    it('should NOT extract code even when it contains the word citations', () => {
+      const content = `JavaScript example:
+
+const data = {
+  citations: ["not", "real", "citations"],
+  function: "test"
+}`;
+
+      const result = extractCitationsFromContent(content);
+      
+      expect(result.text).toBe(content);
+      expect(result.citations).toHaveLength(0);
+      expect(result.extractionMethod).toBe('none');
+    });
+  });
+});

--- a/__tests__/node/utils/app/networkSecurity.test.ts
+++ b/__tests__/node/utils/app/networkSecurity.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+// Mock DNS lookup to control network security tests
+const { mockLookup } = vi.hoisted(() => ({
+  mockLookup: vi.fn(),
+}));
+
+vi.mock('dns', () => ({
+  lookup: mockLookup,
+}));
+
+// Import after mocks are set up
+const { executeSecureRequest, validateResponseContentType } = await import(
+  '@/utils/app/networkSecurity'
+);
+const { HttpError } = await import('@/utils/app/security');
+
+describe('Network Security Utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default DNS lookup to return public IP
+    mockLookup.mockImplementation((hostname, callback) => {
+      if (callback) {
+        callback(null, { address: '8.8.8.8', family: 4 });
+      }
+    });
+  });
+
+  describe('executeSecureRequest', () => {
+    const validUrl = 'https://example.com/test';
+
+    it('should reject localhost URLs', async () => {
+      await expect(
+        executeSecureRequest('http://localhost:8080/admin'),
+      ).rejects.toThrow(HttpError);
+      await expect(
+        executeSecureRequest('http://127.0.0.1/config'),
+      ).rejects.toThrow(HttpError);
+    });
+
+    it('should reject private network URLs', async () => {
+      // Mock DNS to return private IP
+      mockLookup.mockImplementation((hostname, callback) => {
+        if (callback) {
+          callback(null, { address: '192.168.1.1', family: 4 });
+        }
+      });
+
+      await expect(executeSecureRequest(validUrl)).rejects.toThrow(HttpError);
+      expect(mockLookup).toHaveBeenCalledWith(
+        'example.com',
+        expect.any(Function),
+      );
+    });
+
+    it('should reject invalid URLs', async () => {
+      await expect(executeSecureRequest('')).rejects.toThrow(HttpError);
+      await expect(
+        executeSecureRequest('ftp://example.com/file'),
+      ).rejects.toThrow(HttpError);
+      await expect(executeSecureRequest('invalid-url')).rejects.toThrow(
+        HttpError,
+      );
+    });
+
+    it('should make successful request to valid public URLs', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        headers: new Map([['content-type', 'text/html']]),
+        body: {
+          getReader: () => ({
+            read: () => Promise.resolve({ done: true, value: undefined }),
+            releaseLock: () => {},
+          }),
+        },
+      };
+
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const result = await executeSecureRequest(validUrl);
+
+      expect(result.response).toBe(mockResponse);
+      expect(result.finalUrl).toBe(validUrl);
+      expect(result.redirectCount).toBe(0);
+      expect(global.fetch).toHaveBeenCalledWith(
+        validUrl,
+        expect.objectContaining({
+          method: 'GET',
+          redirect: 'manual',
+        }),
+      );
+    });
+
+    it('should handle redirects with security validation', async () => {
+      const redirectUrl = 'https://redirect.example.com/page';
+
+      // First response - redirect
+      const redirectResponse = {
+        ok: false,
+        status: 301,
+        headers: new Map([['location', redirectUrl]]),
+      };
+
+      // Second response - final content
+      const finalResponse = {
+        ok: true,
+        status: 200,
+        headers: new Map([['content-type', 'text/html']]),
+      };
+
+      (global.fetch as any)
+        .mockResolvedValueOnce(redirectResponse)
+        .mockResolvedValueOnce(finalResponse);
+
+      const result = await executeSecureRequest(validUrl);
+
+      expect(result.response).toBe(finalResponse);
+      expect(result.finalUrl).toBe(redirectUrl);
+      expect(result.redirectCount).toBe(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reject redirects to private networks', async () => {
+      const redirectResponse = {
+        ok: false,
+        status: 301,
+        headers: new Map([['location', 'http://192.168.1.100/internal']]),
+      };
+
+      (global.fetch as any).mockResolvedValueOnce(redirectResponse);
+
+      // Mock DNS to return private IP for redirect URL
+      mockLookup.mockImplementation((hostname, callback) => {
+        if (hostname === 'example.com') {
+          callback(null, { address: '8.8.8.8', family: 4 });
+        } else {
+          callback(null, { address: '192.168.1.100', family: 4 });
+        }
+      });
+
+      await expect(executeSecureRequest(validUrl)).rejects.toThrow(HttpError);
+    });
+
+    it('should reject redirects to localhost', async () => {
+      const redirectResponse = {
+        ok: false,
+        status: 301,
+        headers: new Map([['location', 'http://localhost:3000/admin']]),
+      };
+
+      // Mock only the redirect response - the function should throw before making second request
+      (global.fetch as any).mockResolvedValue(redirectResponse);
+
+      await expect(executeSecureRequest(validUrl)).rejects.toThrow(HttpError);
+    });
+
+    it('should handle too many redirects', async () => {
+      const redirectResponse = {
+        ok: false,
+        status: 301,
+        headers: new Map([['location', 'https://redirect.example.com']]),
+      };
+
+      // Always return redirect response
+      (global.fetch as any).mockResolvedValue(redirectResponse);
+
+      await expect(
+        executeSecureRequest(validUrl, { maxRedirects: 3 }),
+      ).rejects.toThrow(HttpError);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should reject server errors', async () => {
+      const errorResponse = {
+        ok: false,
+        status: 500,
+        headers: new Map(),
+      };
+
+      (global.fetch as any).mockResolvedValue(errorResponse);
+
+      await expect(executeSecureRequest(validUrl)).rejects.toThrow(HttpError);
+    });
+
+    it('should handle network errors', async () => {
+      (global.fetch as any).mockRejectedValue(new Error('Network error'));
+
+      await expect(executeSecureRequest(validUrl)).rejects.toThrow(HttpError);
+    });
+
+    it('should handle custom headers and options', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        headers: new Map(),
+      };
+
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      await executeSecureRequest(validUrl, {
+        method: 'POST',
+        headers: { 'Custom-Header': 'test' },
+        userAgent: 'Custom-Agent',
+        additionalHeaders: { Additional: 'header' },
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        validUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Custom-Header': 'test',
+            Additional: 'header',
+            'User-Agent': 'Custom-Agent',
+          }),
+        }),
+      );
+    });
+
+    it('should handle timeout with AbortController', async () => {
+      // Mock a response that respects the AbortSignal
+      (global.fetch as any).mockImplementation((_url: string, options: any) => {
+        return new Promise((resolve, reject) => {
+          const signal = options?.signal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              reject(new Error('The operation was aborted'));
+            });
+          }
+          // Never resolve to simulate a long request
+        });
+      });
+
+      await expect(
+        executeSecureRequest(validUrl, { timeout: 100 }),
+      ).rejects.toThrow(HttpError);
+    }, 10000); // Increase test timeout to 10 seconds
+  });
+
+  describe('validateResponseContentType', () => {
+    const mockResponse = (contentType: string) =>
+      ({
+        headers: new Map([['content-type', contentType]]),
+      } as Response);
+
+    it('should validate allowed content types', () => {
+      const allowedTypes = new Set(['text/html', 'text/plain']);
+      const response = mockResponse('text/html');
+
+      expect(() =>
+        validateResponseContentType(response, { allowedTypes }),
+      ).not.toThrow();
+
+      const result = validateResponseContentType(response, { allowedTypes });
+      expect(result).toBe('text/html');
+    });
+
+    it('should reject disallowed content types', () => {
+      const allowedTypes = new Set(['text/html']);
+      const response = mockResponse('application/json');
+
+      expect(() =>
+        validateResponseContentType(response, { allowedTypes }),
+      ).toThrow(HttpError);
+    });
+
+    it('should block dangerous content types', () => {
+      const blockedTypes = new Set(['application/x-executable']);
+      const response = mockResponse('application/x-executable');
+
+      expect(() =>
+        validateResponseContentType(response, { blockedTypes }),
+      ).toThrow(HttpError);
+    });
+
+    it('should handle wildcard content types', () => {
+      const allowedTypes = new Set(['image/*']);
+      const response = mockResponse('image/jpeg');
+
+      expect(() =>
+        validateResponseContentType(response, { allowedTypes }),
+      ).not.toThrow();
+    });
+
+    it('should return content type when valid', () => {
+      const response = mockResponse('text/html; charset=utf-8');
+      const result = validateResponseContentType(response);
+      expect(result).toBe('text/html; charset=utf-8');
+    });
+  });
+});

--- a/__tests__/node/utils/citationExtractor.test.ts
+++ b/__tests__/node/utils/citationExtractor.test.ts
@@ -1,0 +1,435 @@
+import { CitationExtractor } from '@/utils/citationExtractor';
+
+import { Citation, WebSearchResult } from '@/types/webSearch';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('CitationExtractor', () => {
+  let mockWebSearchResults: WebSearchResult[];
+
+  beforeEach(() => {
+    mockWebSearchResults = [
+      {
+        id: 'result-1',
+        title: 'AI Breakthrough: New Language Model',
+        url: 'https://techcrunch.com/ai-breakthrough',
+        snippet:
+          'Researchers have developed a new language model that shows significant improvements.',
+        displayUrl: 'techcrunch.com/ai-breakthrough',
+        dateLastCrawled: '2024-01-15T10:30:00Z',
+        language: 'en',
+        contentType: 'news',
+        relevanceScore: 0.95,
+        metadata: {
+          author: 'John Smith',
+          publisher: 'TechCrunch',
+          publishedDate: '2024-01-15T08:00:00Z',
+        },
+      },
+      {
+        id: 'result-2',
+        title: 'Machine Learning Paper - Academic Study',
+        url: 'https://arxiv.org/paper/ml-study',
+        snippet:
+          'This academic paper presents novel approaches to machine learning optimization.',
+        displayUrl: 'arxiv.org/paper/ml-study',
+        dateLastCrawled: '2024-01-14T15:45:00Z',
+        language: 'en',
+        contentType: 'academic',
+        relevanceScore: 0.88,
+        metadata: {
+          author: ['Dr. Jane Doe', 'Prof. Bob Wilson'],
+          publisher: 'arXiv',
+        },
+      },
+      {
+        id: 'result-3',
+        title: 'Tech Blog: AI in Daily Life',
+        url: 'https://blog.example.com/ai-daily-life',
+        snippet:
+          'How artificial intelligence is transforming our everyday experiences.',
+        displayUrl: 'blog.example.com/ai-daily-life',
+        dateLastCrawled: '2024-01-13T12:20:00Z',
+        language: 'en',
+        contentType: 'blog',
+        relevanceScore: 0.72,
+        metadata: {},
+      },
+    ];
+  });
+
+  describe('extractCitations', () => {
+    it('should extract citations from web search results', () => {
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+
+      expect(citations).toHaveLength(3);
+      expect(citations[0].id).toBe('cite_1');
+      expect(citations[0].title).toBe('AI Breakthrough: New Language Model');
+      expect(citations[0].url).toBe('https://techcrunch.com/ai-breakthrough');
+      expect(citations[0].type).toBe('news');
+    });
+
+    it('should handle empty results array', () => {
+      const citations = CitationExtractor.extractCitations([]);
+      expect(citations).toHaveLength(0);
+    });
+
+    it('should clean and validate citation titles', () => {
+      const resultsWithDirtyTitles = [
+        {
+          ...mockWebSearchResults[0],
+          title: '  AI Breakthrough: New Language Model - TechCrunch  ',
+        },
+      ];
+
+      const citations = CitationExtractor.extractCitations(
+        resultsWithDirtyTitles,
+      );
+      expect(citations[0].title).toBe('AI Breakthrough: New Language Model');
+    });
+  });
+
+  describe('formatCitationsForDisplay', () => {
+    it('should format citations for display', () => {
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+      const formatted = CitationExtractor.formatCitationsForDisplay(citations);
+
+      expect(formatted).toContain('Sources:');
+      expect(formatted).toContain('[1] AI Breakthrough: New Language Model');
+      expect(formatted).toContain('https://techcrunch.com/ai-breakthrough');
+      expect(formatted).toContain('[2] Machine Learning Paper');
+      expect(formatted).toContain('[3] Tech Blog: AI in Daily Life');
+    });
+
+    it('should return empty string for empty citations', () => {
+      const formatted = CitationExtractor.formatCitationsForDisplay([]);
+      expect(formatted).toBe('');
+    });
+
+    it('should include authors when available', () => {
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+      const formatted = CitationExtractor.formatCitationsForDisplay(citations);
+
+      expect(formatted).toContain('Dr. Jane Doe, Prof. Bob Wilson');
+    });
+
+    it('should include publication dates when available', () => {
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+      const formatted = CitationExtractor.formatCitationsForDisplay(citations);
+
+      expect(formatted).toContain('2024'); // Should include the year from the date
+    });
+  });
+
+  describe('formatInlineCitation', () => {
+    it('should format inline citation references', () => {
+      expect(CitationExtractor.formatInlineCitation(1)).toBe('[1]');
+      expect(CitationExtractor.formatInlineCitation(5)).toBe('[5]');
+      expect(CitationExtractor.formatInlineCitation(10)).toBe('[10]');
+    });
+  });
+
+  describe('insertCitationReferences', () => {
+    it('should insert citation references into content', () => {
+      const content =
+        'Recent breakthroughs in artificial intelligence have shown significant improvements.';
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+
+      const citedContent = CitationExtractor.insertCitationReferences(
+        content,
+        mockWebSearchResults,
+        citations,
+      );
+
+      // The method looks for exact matches from snippets, so use content that matches the snippet
+      expect(citedContent).toContain('breakthroughs');
+    });
+
+    it('should not modify content when no matches found', () => {
+      const content = 'This content has no matching snippets.';
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+
+      const citedContent = CitationExtractor.insertCitationReferences(
+        content,
+        mockWebSearchResults,
+        citations,
+      );
+
+      expect(citedContent).toBe(content);
+    });
+  });
+
+  describe('deduplicateCitations', () => {
+    it('should remove duplicate citations by URL', () => {
+      const duplicateResults = [
+        mockWebSearchResults[0],
+        mockWebSearchResults[0], // Duplicate
+        mockWebSearchResults[1],
+      ];
+
+      const citations = CitationExtractor.extractCitations(duplicateResults);
+      const deduplicated = CitationExtractor.deduplicateCitations(citations);
+
+      expect(deduplicated).toHaveLength(2);
+      expect(deduplicated[0].url).toBe(mockWebSearchResults[0].url);
+      expect(deduplicated[1].url).toBe(mockWebSearchResults[1].url);
+    });
+
+    it('should merge information from duplicate citations', () => {
+      const citation1: Citation = {
+        id: 'cite_1',
+        title: 'Original Title',
+        url: 'https://example.com/article',
+        type: 'article',
+        authors: ['Author 1'],
+        publisher: 'Publisher 1',
+        metadata: { snippet: 'Original snippet' },
+      };
+
+      const citation2: Citation = {
+        id: 'cite_2',
+        title: 'Updated Title',
+        url: 'https://example.com/article',
+        type: 'article',
+        authors: ['Author 2'],
+        publisher: 'Publisher 2',
+        publishedDate: '2024-01-15T10:00:00Z',
+        metadata: { snippet: 'Updated snippet' },
+      };
+
+      const merged = CitationExtractor.deduplicateCitations([
+        citation1,
+        citation2,
+      ]);
+
+      expect(merged).toHaveLength(1);
+      expect(merged[0].title).toBe('Updated Title');
+      expect(merged[0].authors).toContain('Author 1');
+      expect(merged[0].authors).toContain('Author 2');
+      expect(merged[0].publishedDate).toBe('2024-01-15T10:00:00Z');
+    });
+
+    it('should handle URLs with and without trailing slashes', () => {
+      const citation1: Citation = {
+        id: 'cite_1',
+        title: 'Test Article',
+        url: 'https://example.com/article/',
+        type: 'article',
+        publisher: 'Example',
+      };
+
+      const citation2: Citation = {
+        id: 'cite_2',
+        title: 'Test Article',
+        url: 'https://example.com/article',
+        type: 'article',
+        publisher: 'Example',
+      };
+
+      const merged = CitationExtractor.deduplicateCitations([
+        citation1,
+        citation2,
+      ]);
+      expect(merged).toHaveLength(1);
+    });
+  });
+
+  describe('sortCitations', () => {
+    let citations: Citation[];
+
+    beforeEach(() => {
+      citations = CitationExtractor.extractCitations(mockWebSearchResults);
+    });
+
+    it('should sort by relevance (default)', () => {
+      const sorted = CitationExtractor.sortCitations(citations, 'relevance');
+
+      expect(sorted[0].metadata?.relevanceScore).toBe(0.95);
+      expect(sorted[1].metadata?.relevanceScore).toBe(0.88);
+      expect(sorted[2].metadata?.relevanceScore).toBe(0.72);
+    });
+
+    it('should sort by date', () => {
+      const sorted = CitationExtractor.sortCitations(citations, 'date');
+
+      // Most recent first
+      expect(sorted[0].publishedDate).toBe('2024-01-15T08:00:00Z');
+    });
+
+    it('should sort by type', () => {
+      const sorted = CitationExtractor.sortCitations(citations, 'type');
+
+      // Academic first, then news, then blog
+      expect(sorted[0].type).toBe('academic');
+      expect(sorted[1].type).toBe('news');
+      expect(sorted[2].type).toBe('blog');
+    });
+
+    it('should handle missing metadata gracefully', () => {
+      const citationsWithoutMetadata = citations.map((c) => ({
+        ...c,
+        metadata: {},
+      }));
+
+      const sorted = CitationExtractor.sortCitations(
+        citationsWithoutMetadata,
+        'relevance',
+      );
+      expect(sorted).toHaveLength(3);
+    });
+  });
+
+  describe('Citation Type Detection', () => {
+    it('should detect academic sources', () => {
+      const academicResult: WebSearchResult = {
+        id: 'academic-1',
+        title: 'Research Paper',
+        url: 'https://scholar.google.com/paper',
+        snippet: 'Academic research paper',
+        displayUrl: 'scholar.google.com/paper',
+        dateLastCrawled: new Date().toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {},
+      };
+
+      const citations = CitationExtractor.extractCitations([academicResult]);
+      expect(citations[0].type).toBe('academic');
+    });
+
+    it('should detect news sources', () => {
+      const newsResult: WebSearchResult = {
+        id: 'news-1',
+        title: 'Breaking News Article',
+        url: 'https://cnn.com/news/article',
+        snippet: 'Latest news update',
+        displayUrl: 'cnn.com/news/article',
+        dateLastCrawled: new Date().toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {},
+      };
+
+      const citations = CitationExtractor.extractCitations([newsResult]);
+      expect(citations[0].type).toBe('news');
+    });
+
+    it('should detect blog sources', () => {
+      const blogResult: WebSearchResult = {
+        id: 'blog-1',
+        title: 'Personal Blog Post',
+        url: 'https://myblog.com/post',
+        snippet: 'Personal thoughts and opinions',
+        displayUrl: 'myblog.com/post',
+        dateLastCrawled: new Date().toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {},
+      };
+
+      const citations = CitationExtractor.extractCitations([blogResult]);
+      expect(citations[0].type).toBe('blog');
+    });
+
+    it('should default to webpage for unknown sources', () => {
+      const unknownResult: WebSearchResult = {
+        id: 'unknown-1',
+        title: 'Some Website',
+        url: 'https://randomsite.com/page',
+        snippet: 'Random content',
+        displayUrl: 'randomsite.com/page',
+        dateLastCrawled: new Date().toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {},
+      };
+
+      const citations = CitationExtractor.extractCitations([unknownResult]);
+      expect(citations[0].type).toBe('webpage');
+    });
+  });
+
+  describe('Date Formatting', () => {
+    it('should format recent dates with month and day', () => {
+      const recentDate = new Date();
+      recentDate.setMonth(recentDate.getMonth() - 1); // 1 month ago
+
+      const result: WebSearchResult = {
+        id: 'recent-1',
+        title: 'Recent Article',
+        url: 'https://example.com/recent',
+        snippet: 'Recent content',
+        displayUrl: 'example.com/recent',
+        dateLastCrawled: recentDate.toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {
+          publishedDate: recentDate.toISOString(),
+        },
+      };
+
+      const citations = CitationExtractor.extractCitations([result]);
+      const formatted = CitationExtractor.formatCitationsForDisplay(citations);
+
+      expect(formatted).toMatch(/\w{3} \d{1,2}, \d{4}/); // e.g., "Jan 15, 2024"
+    });
+
+    it('should format old dates with year only', () => {
+      const oldDate = new Date('2020-01-15T10:00:00Z');
+
+      const result: WebSearchResult = {
+        id: 'old-1',
+        title: 'Old Article',
+        url: 'https://example.com/old',
+        snippet: 'Old content',
+        displayUrl: 'example.com/old',
+        dateLastCrawled: oldDate.toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {
+          publishedDate: oldDate.toISOString(),
+        },
+      };
+
+      const citations = CitationExtractor.extractCitations([result]);
+      const formatted = CitationExtractor.formatCitationsForDisplay(citations);
+
+      expect(formatted).toContain('2020');
+    });
+  });
+
+  describe('Publisher Extraction', () => {
+    it('should extract publisher from metadata when available', () => {
+      const citations =
+        CitationExtractor.extractCitations(mockWebSearchResults);
+
+      expect(citations[0].publisher).toBe('TechCrunch');
+      expect(citations[1].publisher).toBe('arXiv');
+    });
+
+    it('should extract publisher from domain when metadata not available', () => {
+      const resultWithoutPublisher: WebSearchResult = {
+        id: 'no-publisher',
+        title: 'Article Title',
+        url: 'https://www.example.com/article',
+        snippet: 'Article content',
+        displayUrl: 'www.example.com/article',
+        dateLastCrawled: new Date().toISOString(),
+        language: 'en',
+        relevanceScore: 0.9,
+        metadata: {},
+      };
+
+      const citations = CitationExtractor.extractCitations([
+        resultWithoutPublisher,
+      ]);
+      expect(citations[0].publisher).toBe('example.com');
+    });
+  });
+});

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { IconArrowDown, IconRepeat } from '@tabler/icons-react';
-import {
+import React, {
   Dispatch,
   KeyboardEvent,
   MutableRefObject,

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -152,6 +152,7 @@ export const ChatInput = ({
   const [promptInputValue, setPromptInputValue] = useState<string>('');
   const [variables, setVariables] = useState<string[]>([]);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+  const [selectedPrompt, setSelectedPrompt] = useState<Prompt | null>(null);
   const [showPluginSelect, setShowPluginSelect] = useState<boolean>(false);
   const [plugin, setPlugin] = useState<Plugin | null>(null);
   const [submitType, setSubmitType] = useState<ChatInputSubmitTypes>('text');
@@ -707,6 +708,7 @@ export const ChatInput = ({
     setVariables(parsedVariables);
 
     if (parsedVariables.length > 0) {
+      setSelectedPrompt(prompt);  // Store the selected prompt
       setIsModalVisible(true);
     } else {
       setTextFieldValue((prevContent) => {
@@ -1377,12 +1379,15 @@ export const ChatInput = ({
             )}
           </div>
 
-          {isModalVisible && (
+          {isModalVisible && selectedPrompt && (
             <VariableModal
-              prompt={sortedFilteredPrompts[activePromptIndex]}
+              prompt={selectedPrompt}
               variables={variables}
               onSubmit={handleSubmit}
-              onClose={() => setIsModalVisible(false)}
+              onClose={() => {
+                setIsModalVisible(false);
+                setSelectedPrompt(null);  // Clear selected prompt when closing
+              }}
             />
           )}
         </div>

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -152,7 +152,7 @@ export const ChatInput = ({
   const [promptInputValue, setPromptInputValue] = useState<string>('');
   const [variables, setVariables] = useState<string[]>([]);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-  const [selectedPrompt, setSelectedPrompt] = useState<Prompt | null>(null);
+  const [promptForVariableModal, setPromptForVariableModal] = useState<Prompt | null>(null);
   const [showPluginSelect, setShowPluginSelect] = useState<boolean>(false);
   const [plugin, setPlugin] = useState<Plugin | null>(null);
   const [submitType, setSubmitType] = useState<ChatInputSubmitTypes>('text');
@@ -499,7 +499,7 @@ export const ChatInput = ({
    * Unified handler for selecting items from the dropdown (commands or prompts)
    * @param index - The index of the selected item in the combined list
    */
-  const handleItemSelection = (index: number) => {
+  const handleDropdownItemSelection = (index: number) => {
     const commandsCount = commandMode ? filteredCommands.length : 0;
     
     if (index < commandsCount) {
@@ -580,7 +580,7 @@ export const ChatInput = ({
         break;
       case 'Enter':
         event.preventDefault();
-        handleItemSelection(activePromptIndex);
+        handleDropdownItemSelection(activePromptIndex);
         if (submitType !== 'text') {
           setSubmitType('text');
         }
@@ -708,7 +708,7 @@ export const ChatInput = ({
     setVariables(parsedVariables);
 
     if (parsedVariables.length > 0) {
-      setSelectedPrompt(prompt);  // Store the selected prompt
+      setPromptForVariableModal(prompt);  // Store the selected prompt for the variable modal
       setIsModalVisible(true);
     } else {
       setTextFieldValue((prevContent) => {
@@ -1246,7 +1246,7 @@ export const ChatInput = ({
                     prompts={sortedFilteredPrompts}
                     commands={filteredCommands}
                     showCommands={commandMode}
-                    onSelect={handleItemSelection}
+                    onSelect={handleDropdownItemSelection}
                     onMouseOver={setActivePromptIndex}
                     promptListRef={promptListRef}
                     onImmediateCommandExecution={(command) => {
@@ -1379,14 +1379,14 @@ export const ChatInput = ({
             )}
           </div>
 
-          {isModalVisible && selectedPrompt && (
+          {isModalVisible && promptForVariableModal && (
             <VariableModal
-              prompt={selectedPrompt}
+              prompt={promptForVariableModal}
               variables={variables}
               onSubmit={handleSubmit}
               onClose={() => {
                 setIsModalVisible(false);
-                setSelectedPrompt(null);  // Clear selected prompt when closing
+                setPromptForVariableModal(null);  // Clear prompt for variable modal when closing
               }}
             />
           )}

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -494,27 +494,35 @@ export const ChatInput = ({
     return mobileRegex.test(userAgent);
   };
 
-  const handleInitModal = () => {
-    if (commandMode && filteredCommands.length > 0) {
-      // Handle command selection - use original filteredCommands for commands
-      const selectedCommand = filteredCommands[activePromptIndex];
-      if (selectedCommand) {
-        handleCommandSelect(selectedCommand);
+  /**
+   * Unified handler for selecting items from the dropdown (commands or prompts)
+   * @param index - The index of the selected item in the combined list
+   */
+  const handleItemSelection = (index: number) => {
+    const commandsCount = commandMode ? filteredCommands.length : 0;
+    
+    if (index < commandsCount) {
+      // It's a command
+      const command = filteredCommands[index];
+      if (command) {
+        handleCommandSelect(command);
       }
     } else {
-      // Handle prompt selection - use sorted prompts
-      const selectedPrompt = sortedFilteredPrompts[activePromptIndex];
-      if (selectedPrompt) {
+      // It's a prompt
+      const promptIndex = index - commandsCount;
+      const prompt = sortedFilteredPrompts[promptIndex];
+      if (prompt) {
         setTextFieldValue((prevTextFieldValue) => {
           const newContent = prevTextFieldValue?.replace(
             /\/\w*$/,
-            selectedPrompt.content,
+            prompt.content,
           );
           return newContent;
         });
-        handlePromptSelect(selectedPrompt);
+        handlePromptSelect(prompt);
       }
     }
+    
     setShowPromptList(false);
   };
 
@@ -571,7 +579,7 @@ export const ChatInput = ({
         break;
       case 'Enter':
         event.preventDefault();
-        handleInitModal();
+        handleItemSelection(activePromptIndex);
         if (submitType !== 'text') {
           setSubmitType('text');
         }
@@ -1236,7 +1244,7 @@ export const ChatInput = ({
                     prompts={sortedFilteredPrompts}
                     commands={filteredCommands}
                     showCommands={commandMode}
-                    onSelect={handleInitModal}
+                    onSelect={handleItemSelection}
                     onMouseOver={setActivePromptIndex}
                     promptListRef={promptListRef}
                     onImmediateCommandExecution={(command) => {

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -14,6 +14,7 @@ import React, {
 import toast from 'react-hot-toast';
 
 import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
 
 import {
   CommandDefinition,
@@ -120,6 +121,8 @@ export const ChatInput = ({
   onAddChatMessages,
 }: Props) => {
   const { t } = useTranslation('chat');
+  const router = useRouter();
+  const currentLocale = router.locale || 'en';
 
   const {
     state: {
@@ -324,7 +327,7 @@ export const ChatInput = ({
         currentMessage: currentMessage,
       };
 
-      const parsed = commandParser.parseLocalizedInput(textFieldValue, 'en'); // TODO: Use actual locale
+      const parsed = commandParser.parseLocalizedInput(textFieldValue, currentLocale);
       if (parsed && parsed.valid) {
         const executionResult = commandParser.executeCommand(
           parsed,
@@ -673,9 +676,9 @@ export const ChatInput = ({
         };
         const parsed = commandParser.parseLocalizedInput(
           input,
-          'en',
+          currentLocale,
           commandContext,
-        ); // TODO: Use actual locale
+        );
         setParsedCommand(parsed);
 
         // Show prompt list and set command mode

--- a/components/Chat/PromptList.tsx
+++ b/components/Chat/PromptList.tsx
@@ -4,7 +4,7 @@ import {
   IconRobot,
   IconSettings,
 } from '@tabler/icons-react';
-import { FC, MutableRefObject, useState } from 'react';
+import React, { FC, MutableRefObject, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 

--- a/components/Chat/PromptList.tsx
+++ b/components/Chat/PromptList.tsx
@@ -15,7 +15,7 @@ import { Prompt } from '@/types/prompt';
 interface Props {
   prompts: Prompt[];
   activePromptIndex: number;
-  onSelect: () => void;
+  onSelect: (index: number) => void;
   onMouseOver: (index: number) => void;
   promptListRef: MutableRefObject<HTMLUListElement | null>;
   commands?: CommandDefinition[];
@@ -186,14 +186,8 @@ export const PromptList: FC<Props> = ({
   const commandsCount = showCommands ? commands.length : 0;
 
   const handleItemClick = (index: number) => {
-    if (showCommands && index < commandsCount) {
-      // This is a command - handle command selection
-      // For now, we'll just call onSelect, but this could be extended
-      onSelect();
-    } else {
-      // This is a prompt
-      onSelect();
-    }
+    // Pass the index directly to the parent handler
+    onSelect(index);
   };
 
   const handleItemMouseEnter = (index: number) => {

--- a/config/agents/registry.ts
+++ b/config/agents/registry.ts
@@ -759,7 +759,7 @@ const AGENT_DEFINITIONS: Record<AgentType, AgentDefinition> = {
       name: 'Code Interpreter Agent',
       description: 'Execute and analyze code in secure sandboxed environment',
       version: '1.0.0',
-      enabled: true,
+      enabled: false, // Disabled - not ready for production yet
     },
     commands: {
       primary: 'code',

--- a/services/commandParser.ts
+++ b/services/commandParser.ts
@@ -240,7 +240,7 @@ export class CommandParser {
       { command: 'translate', agentType: AgentType.TRANSLATION, name: 'translation agent' },
       { command: 'url', agentType: AgentType.URL_PULL, name: 'URL pull agent' },
       { command: 'knowledge', agentType: AgentType.LOCAL_KNOWLEDGE, name: 'local knowledge agent' },
-      { command: 'code', agentType: AgentType.CODE_INTERPRETER, name: 'code interpreter agent' },
+      // { command: 'code', agentType: AgentType.CODE_INTERPRETER, name: 'code interpreter agent' }, // Disabled - not ready for production
     ];
 
     for (const cmd of fallbackCommands) {

--- a/services/frontendChatServices.ts
+++ b/services/frontendChatServices.ts
@@ -227,12 +227,12 @@ Document metadata: ${filename}
       if (content.type === 'file_url') {
         fileSummaries.push({
           filename: content.originalFilename,
-          summary: responseData.text ?? '',
+          summary: responseData.data?.text ?? responseData.text ?? '',
         });
       } else {
         fileSummaries.push({
           filename: `Image: ${content.image_url.url.split('/').pop()}`,
-          summary: responseData.text ?? '',
+          summary: responseData.data?.text ?? responseData.text ?? '',
         });
       }
 

--- a/services/frontendChatServices.ts
+++ b/services/frontendChatServices.ts
@@ -15,7 +15,7 @@ import {
 } from '@/types/chat';
 import { Plugin, PluginID } from '@/types/plugin';
 
-const isComplexContent = (
+export const isComplexContent = (
   content: (TextMessageContent | ImageMessageContent | FileMessageContent)[],
 ): boolean => {
   const contentTypes = content.map((section) => section.type);
@@ -27,7 +27,7 @@ const isComplexContent = (
   );
 };
 
-const createChatBody = (
+export const createChatBody = (
   conversation: Conversation,
   messages: Message[],
   apiKey: string,
@@ -51,7 +51,7 @@ const createChatBody = (
   ...(forcedAgentType && { forceAgentType: forcedAgentType }),
 });
 
-const appendPluginKeys = (
+export const appendPluginKeys = (
   chatBody: ChatBody,
   pluginKeys: { pluginId: PluginID; requiredKeys: any[] }[],
 ) => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,14 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "__tests__/**/*",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "vitest.*.ts",
+    "test-*.js"
+  ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,46 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Relax strict type checking for tests
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "strictFunctionTypes": false,
+    "strictBindCallApply": false,
+    "strictPropertyInitialization": false,
+    "noImplicitThis": false,
+    "alwaysStrict": false,
+    
+    // Allow more flexibility in tests
+    "allowUnreachableCode": true,
+    "allowUnusedLabels": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    
+    // Keep other important settings
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    
+    // Test-specific types
+    "types": ["vitest/globals", "node", "@testing-library/jest-dom"]
+  },
+  "include": [
+    "__tests__/**/*",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts", 
+    "**/*.spec.tsx",
+    "vitest.*.ts",
+    "test-*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next",
+    "out",
+    "dist"
+  ]
+}

--- a/vitest.config.jsdom.ts
+++ b/vitest.config.jsdom.ts
@@ -13,4 +13,11 @@ export default defineConfig({
       '@': path.resolve(__dirname, './'),
     },
   },
+  esbuild: {
+    tsconfigRaw: {
+      compilerOptions: {
+        strict: false,
+      },
+    },
+  },
 });

--- a/vitest.config.node.ts
+++ b/vitest.config.node.ts
@@ -13,4 +13,11 @@ export default defineConfig({
       '@': path.resolve(__dirname, './'),
     },
   },
+  esbuild: {
+    tsconfigRaw: {
+      compilerOptions: {
+        strict: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Request from internal: prompts were broken with the commands implementation.

The caused seemed to be that prompts assumed an index that was invalid once commands were mixed in. This was also an issue with prompt variables, separate from simple prompts but with the same root problem.

This fixes both while keeping the command functionality working as well.

---

Added issue: Sarah Autry found out there was a problem with multifile uploads. This is caused by a mismatch in data structure between v1 and v2 api endpoints, which caused the final request to lack the legitimate summaries that were found in the previous steps.

This code also fixes that and adds unit testing for making sure v2 works. It also includes some tests for backwards compatibility with v1, though we should get rid of v1 soon.